### PR TITLE
Add /logging command and config to enable/disable debug logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>

--- a/src/main/java/gg/playit/control/ChannelSetup.java
+++ b/src/main/java/gg/playit/control/ChannelSetup.java
@@ -6,6 +6,7 @@ import gg.playit.messages.ControlFeedReader;
 import gg.playit.messages.ControlRequestWriter;
 import gg.playit.messages.DecodeException;
 import gg.playit.minecraft.utils.DecoderException;
+import gg.playit.minecraft.utils.Logger;
 
 import java.io.IOException;
 import java.net.*;
@@ -13,12 +14,11 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.logging.Logger;
 
 public class ChannelSetup {
     public static final int CONTROL_PORT = 5525;
 
-    static Logger log = Logger.getLogger(ChannelSetup.class.getName());
+    static Logger log = new Logger(ChannelSetup.class.getName());
 
     public static FindSuitableChannel start() throws UnknownHostException {
         InetAddress[] allByName = InetAddress.getAllByName("control.playit.gg");
@@ -155,7 +155,7 @@ public class ChannelSetup {
 
                         if (response instanceof ControlFeedReader.Error error) {
                             if (error == ControlFeedReader.Error.RequestQueued) {
-                                log.info("request queued, waiting 1 second before resend");
+                                log.debug("request queued, waiting 1 second before resend");
 
                                 try {
                                     Thread.sleep(1000);

--- a/src/main/java/gg/playit/control/PlayitControlChannel.java
+++ b/src/main/java/gg/playit/control/PlayitControlChannel.java
@@ -4,6 +4,7 @@ import gg.playit.api.ApiClient;
 import gg.playit.messages.ControlFeedReader;
 import gg.playit.messages.ControlRequestWriter;
 import gg.playit.messages.DecodeException;
+import gg.playit.minecraft.utils.Logger;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -16,12 +17,11 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 import static gg.playit.control.ChannelSetup.CONTROL_PORT;
 
 public class PlayitControlChannel implements Closeable {
-    static Logger log = Logger.getLogger(ChannelSetup.class.getName());
+    static Logger log = new Logger(ChannelSetup.class.getName());
 
     ApiClient apiClient;
     DatagramSocket socket;
@@ -57,7 +57,7 @@ public class PlayitControlChannel implements Closeable {
 
             var tillExpire = this.registered.expiresAt - now;
             if (tillExpire < 60_000 && 10_000 < now - lastKeepAlive) {
-                log.info("send keep alive");
+                log.debug("send keep alive");
                 lastKeepAlive = now;
 
                 this.sendKeepAlive();

--- a/src/main/java/gg/playit/minecraft/PlayitBukkit.java
+++ b/src/main/java/gg/playit/minecraft/PlayitBukkit.java
@@ -23,7 +23,7 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
     public static final String CFG_AGENT_SECRET_KEY = "agent-secret";
     public static final String CFG_CONNECTION_TIMEOUT_SECONDS = "mc-timeout-sec";
     public static final String CFG_DEBUG_LOGGING = "debug-logging";
-    public static boolean debugLoggingEnabled = false;
+    private static boolean debugLogging = false;
 
     static Logger log = new Logger(PlayitBukkit.class.getName());
     final EventLoopGroup eventGroup = new NioEventLoopGroup();
@@ -54,9 +54,9 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
 
         var debugLogging = getConfig().getString(CFG_DEBUG_LOGGING);
         if ("true".equals(debugLogging)) {
-            debugLoggingEnabled = true;
+            PlayitBukkit.debugLogging = true;
         } else if ("false".equals(debugLogging)) {
-            debugLoggingEnabled = false;
+            PlayitBukkit.debugLogging = false;
         }
 
         try {
@@ -260,7 +260,7 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
         if (args.length > 0 && args[0].equals("logging")) {
             if (args.length > 1 && args[1].equals("enable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, true);
-                debugLoggingEnabled = true;
+                setDebugLogging(true);
 
                 sender.sendMessage("enabled debug logging");
                 return true;
@@ -268,7 +268,7 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
 
             if (args.length > 1 && args[1].equals("disable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, false);
-                debugLoggingEnabled = false;
+                setDebugLogging(false);
 
                 sender.sendMessage("disabled debug logging");
                 return true;
@@ -364,5 +364,13 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
             playitManager.shutdown();
             playitManager = null;
         }
+    }
+
+    public static boolean hasDebugLogging() {
+        return debugLogging;
+    }
+
+    public void setDebugLogging(boolean debugLogging) {
+        PlayitBukkit.debugLogging = debugLogging;
     }
 }

--- a/src/main/java/gg/playit/minecraft/PlayitBukkit.java
+++ b/src/main/java/gg/playit/minecraft/PlayitBukkit.java
@@ -261,6 +261,7 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
         if (args.length > 0 && args[0].equals("logging")) {
             if (args.length > 1 && args[1].equals("enable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, true);
+                saveConfig();
                 setDebugLogging(true);
                 sender.sendMessage("enabled debug logging");
                 return true;
@@ -268,6 +269,7 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
 
             if (args.length > 1 && args[1].equals("disable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, false);
+                saveConfig();
                 setDebugLogging(false);
                 sender.sendMessage("disabled debug logging");
                 return true;

--- a/src/main/java/gg/playit/minecraft/PlayitBukkit.java
+++ b/src/main/java/gg/playit/minecraft/PlayitBukkit.java
@@ -54,10 +54,11 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
 
         var debugLogging = getConfig().getString(CFG_DEBUG_LOGGING);
         if ("true".equals(debugLogging)) {
-            PlayitBukkit.debugLogging = true;
+            setDebugLogging(true);
         } else if ("false".equals(debugLogging)) {
-            PlayitBukkit.debugLogging = false;
+            setDebugLogging(false);
         }
+        getConfig().set(CFG_DEBUG_LOGGING, hasDebugLogging());
 
         try {
             PluginManager pm = Bukkit.getServer().getPluginManager();
@@ -261,7 +262,6 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
             if (args.length > 1 && args[1].equals("enable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, true);
                 setDebugLogging(true);
-
                 sender.sendMessage("enabled debug logging");
                 return true;
             }
@@ -269,7 +269,6 @@ public final class PlayitBukkit extends JavaPlugin implements Listener {
             if (args.length > 1 && args[1].equals("disable")) {
                 getConfig().set(CFG_DEBUG_LOGGING, false);
                 setDebugLogging(false);
-
                 sender.sendMessage("disabled debug logging");
                 return true;
             }

--- a/src/main/java/gg/playit/minecraft/ReflectionHelper.java
+++ b/src/main/java/gg/playit/minecraft/ReflectionHelper.java
@@ -1,5 +1,6 @@
 package gg.playit.minecraft;
 
+import gg.playit.minecraft.utils.Logger;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import org.bukkit.Server;
@@ -9,10 +10,9 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class ReflectionHelper {
-    static Logger log = Logger.getLogger(ReflectionHelper.class.getName());
+    static Logger log = new Logger(ReflectionHelper.class.getName());
 
     private final Class<?> ServerConnection;
     private final Class<?> LegacyPingHandler;

--- a/src/main/java/gg/playit/minecraft/utils/Logger.java
+++ b/src/main/java/gg/playit/minecraft/utils/Logger.java
@@ -5,10 +5,14 @@ import org.slf4j.LoggerFactory;
 
 public class Logger {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("playit-minecraft-plugin");
+    private final ServerConfiguration serverConfig;
     public final String className;
 
     public Logger(String className) {
         this.className = className;
+        this.serverConfig = new ServerConfiguration();
+
+        serverConfig.init();
     }
 
     public void info(String format, Object... data) {
@@ -16,19 +20,19 @@ public class Logger {
     }
 
     public void debug(String format, Object... data) {
-        if (PlayitBukkit.hasDebugLogging()) {
-            LOGGER.debug("[" + className + "] " + format, data);
+        if (PlayitBukkit.hasDebugLogging() || serverConfig.debugModeEnabled()) {
+            LOGGER.info("[" + className + "] " + format, data);
         }
     }
 
     public void error(String format, Object... data) {
-        if (PlayitBukkit.hasDebugLogging()) {
+        if (PlayitBukkit.hasDebugLogging() || serverConfig.debugModeEnabled()) {
             LOGGER.error("[" + className + "] " + format, data);
         }
     }
 
     public void warning(String format, Object... data) {
-        if (PlayitBukkit.hasDebugLogging()) {
+        if (PlayitBukkit.hasDebugLogging() || serverConfig.debugModeEnabled()) {
             LOGGER.warn("[" + className + "] " + format, data);
         }
     }

--- a/src/main/java/gg/playit/minecraft/utils/Logger.java
+++ b/src/main/java/gg/playit/minecraft/utils/Logger.java
@@ -16,19 +16,19 @@ public class Logger {
     }
 
     public void debug(String format, Object... data) {
-        if (PlayitBukkit.debugLoggingEnabled) {
+        if (PlayitBukkit.hasDebugLogging()) {
             LOGGER.debug("[" + className + "] " + format, data);
         }
     }
 
     public void error(String format, Object... data) {
-        if (PlayitBukkit.debugLoggingEnabled) {
+        if (PlayitBukkit.hasDebugLogging()) {
             LOGGER.error("[" + className + "] " + format, data);
         }
     }
 
     public void warning(String format, Object... data) {
-        if (PlayitBukkit.debugLoggingEnabled) {
+        if (PlayitBukkit.hasDebugLogging()) {
             LOGGER.warn("[" + className + "] " + format, data);
         }
     }

--- a/src/main/java/gg/playit/minecraft/utils/Logger.java
+++ b/src/main/java/gg/playit/minecraft/utils/Logger.java
@@ -1,0 +1,35 @@
+package gg.playit.minecraft.utils;
+
+import gg.playit.minecraft.PlayitBukkit;
+import org.slf4j.LoggerFactory;
+
+public class Logger {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("playit-minecraft-plugin");
+    public final String className;
+
+    public Logger(String className) {
+        this.className = className;
+    }
+
+    public void info(String format, Object... data) {
+        LOGGER.info("[" + className + "] " + format, data);
+    }
+
+    public void debug(String format, Object... data) {
+        if (PlayitBukkit.debugLoggingEnabled) {
+            LOGGER.debug("[" + className + "] " + format, data);
+        }
+    }
+
+    public void error(String format, Object... data) {
+        if (PlayitBukkit.debugLoggingEnabled) {
+            LOGGER.error("[" + className + "] " + format, data);
+        }
+    }
+
+    public void warning(String format, Object... data) {
+        if (PlayitBukkit.debugLoggingEnabled) {
+            LOGGER.warn("[" + className + "] " + format, data);
+        }
+    }
+}

--- a/src/main/java/gg/playit/minecraft/utils/ServerConfiguration.java
+++ b/src/main/java/gg/playit/minecraft/utils/ServerConfiguration.java
@@ -1,0 +1,32 @@
+package gg.playit.minecraft.utils;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ServerConfiguration {
+    private final FileConfiguration spigotConfig;
+
+    public ServerConfiguration() {
+        spigotConfig = new YamlConfiguration();
+    }
+
+    public void init() {
+        try {
+            spigotConfig.load(new File("spigot.yml"));
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean debugModeEnabled() {
+        if (spigotConfig != null) {
+            return spigotConfig.getBoolean("settings.debug");
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,3 @@
 mc-timeout-sec: 30
 agent-secret: ""
+debug-logging: false


### PR DESCRIPTION
You can now enable debug logging by running `/playit logging enable` and disable debug logging by using `/playit logging disable`. The plugin now uses SLF4J for logging.

Fixes #21
